### PR TITLE
Feat/26 location table filter

### DIFF
--- a/src/components/DropBoxContainer.vue
+++ b/src/components/DropBoxContainer.vue
@@ -9,42 +9,6 @@
         :locations="locations"
       />
 
-      <b-row class="my-1 table-filter">
-        <b-col sm="4">
-          <label for="input-default">Filter the table:</label>
-        </b-col>
-        <b-col sm="8">
-          <b-form-input v-model="searchTerm" placeholder="Search Term"></b-form-input>
-          <span class="mt-2">Value: {{ searchTerm }}</span>
-        </b-col>
-      </b-row>
-
-      <div>
-        <table class="table table-responsive table-striped table-hover mt-4 text-left w-auto">
-          <thead class="thead-light">
-            <tr>
-              <th>City</th>
-              <th>Location Name</th>
-              <th>Address</th>
-              <th width=100>Zip</th>
-              <th>Hours</th>
-            </tr>
-          </thead>
-          <tbody v-if="filteredLocations && filteredLocations.length">
-            <tr v-for="(location, index) in filteredLocations" :key="index">
-              <td>{{location.City}}</td>
-              <td>{{location.Name}}</td>
-              <td>{{location.Address}}</td>
-              <td>{{location.Zip}}</td>
-              <td>{{location.Hours}}</td>
-            </tr>
-          </tbody>
-          <tbody v-else>
-            No cities match your search term
-          </tbody>
-        </table>
-      </div>
-
       <b-form-group
         label="Filter By City"
         label-size="md"
@@ -70,7 +34,7 @@
         :fields="fields"
         :filter="filter"
         :filter-included-fields="filterOn"
-        empty-text="No locations found"
+        empty-text="Ballot drop off locations coming soon!"
         empty-filtered-text="No locations match that search term"
         hover
         responsive="sm"
@@ -81,12 +45,12 @@
       >
         <!-- show the empty-text if no locatiions -->
         <template v-slot:empty="scope">
-          <h4>{{ scope.emptyText }}</h4>
+          <h4 class="text-center">{{ scope.emptyText }}</h4>
         </template>
 
         <!-- show the empty-filtered-text if no locatiions match the search term-->
         <template v-slot:emptyfiltered="scope">
-          <h4>{{ scope.emptyFilteredText }}</h4>
+          <h4 class="text-center">{{ scope.emptyFilteredText }}</h4>
         </template>
 
         <!-- display the table when it has location data -->
@@ -98,9 +62,6 @@
           </b-card>
         </template>
       </b-table>
-    </div>
-    <div v-else>
-      Ballot drop off locations coming soon!
     </div>
   </div>
 </template>
@@ -118,11 +79,6 @@ export default {
   data: function() {
     return {
       locations: null,
-      searchTerm: "",
-
-      sortBy: '',
-      sortDesc: false,
-      sortDirection: 'asc',
       filter: null,
       filterOn: ["City"],
       fields: [
@@ -130,8 +86,6 @@ export default {
           key: 'City',
           label: 'City',
           filterByFormatted: true,
-          sortable: true,
-          sortDirection: 'desc',
         },
         { key: 'Name', label: 'Location Name' },
         { key: 'Address', label: 'Address' },
@@ -164,14 +118,6 @@ export default {
   watch: {
     county_fips: function() {
       this.getData();
-    }
-  },
-  computed: {
-    filteredLocations: function() {
-      // get the locations with a city name that match the search term
-      const searchTerm = this.searchTerm.toLowerCase();
-      const filteredLocs = this.locations.filter(loc => loc.City.toLowerCase().includes(searchTerm));
-      return filteredLocs;
     }
   },
   mounted() {

--- a/src/components/DropBoxContainer.vue
+++ b/src/components/DropBoxContainer.vue
@@ -4,14 +4,23 @@
       <h3>Ballot Drop Locations</h3>
 
       <GoogleMap
-          id="map"
-          v-if="locations"
-          :locations="locations"
+        id="map"
+        v-if="locations"
+        :locations="locations"
       />
 
+      <b-row class="my-1 table-filter">
+        <b-col sm="4">
+          <label for="input-default">Filter the table:</label>
+        </b-col>
+        <b-col sm="8">
+          <b-form-input v-model="searchTerm" placeholder="Search Term"></b-form-input>
+          <span class="mt-2">Value: {{ searchTerm }}</span>
+        </b-col>
+      </b-row>
 
-        <div class="table-responsive">
-        <table v-if="locations" class="table table-responsive table-striped table-hover mt-4 text-left">
+      <div>
+        <table class="table table-responsive table-striped table-hover mt-4 text-left w-auto">
           <thead class="thead-light">
             <tr>
               <th>City</th>
@@ -19,11 +28,10 @@
               <th>Address</th>
               <th width=100>Zip</th>
               <th>Hours</th>
-    <!--      <td>Map</td>-->
             </tr>
           </thead>
-          <tbody class="">
-            <tr v-for="(location, index) in locations" :key="index" >
+          <tbody v-if="filteredLocations && filteredLocations.length">
+            <tr v-for="(location, index) in filteredLocations" :key="index">
               <td>{{location.City}}</td>
               <td>{{location.Name}}</td>
               <td>{{location.Address}}</td>
@@ -31,8 +39,65 @@
               <td>{{location.Hours}}</td>
             </tr>
           </tbody>
+          <tbody v-else>
+            No cities match your search term
+          </tbody>
         </table>
-        </div>
+      </div>
+
+      <b-form-group
+        label="Filter By City"
+        label-size="md"
+        label-for="filterInput"
+        label-cols="auto"
+        class="mb-2 mt-4"
+      >
+        <b-input-group size="md">
+          <b-form-input
+            v-model="filter"
+            type="search"
+            id="filterInput"
+            placeholder="Type to Search"
+          ></b-form-input>
+          <b-input-group-append>
+            <b-button :disabled="!filter" @click="filter = ''">Clear</b-button>
+          </b-input-group-append>
+        </b-input-group>
+      </b-form-group>
+
+      <b-table
+        :items="locations"
+        :fields="fields"
+        :filter="filter"
+        :filter-included-fields="filterOn"
+        empty-text="No locations found"
+        empty-filtered-text="No locations match that search term"
+        hover
+        responsive="sm"
+        show-empty
+        small
+        striped
+        text-left
+      >
+        <!-- show the empty-text if no locatiions -->
+        <template v-slot:empty="scope">
+          <h4>{{ scope.emptyText }}</h4>
+        </template>
+
+        <!-- show the empty-filtered-text if no locatiions match the search term-->
+        <template v-slot:emptyfiltered="scope">
+          <h4>{{ scope.emptyFilteredText }}</h4>
+        </template>
+
+        <!-- display the table when it has location data -->
+        <template v-slot:row-details="row">
+          <b-card>
+            <ul>
+              <li v-for="(value, key) in row.item" :key="key">{{ key }}: {{ value }}</li>
+            </ul>
+          </b-card>
+        </template>
+      </b-table>
     </div>
     <div v-else>
       Ballot drop off locations coming soon!
@@ -50,9 +115,29 @@ export default {
   props: {
     county_fips: String,
   },
-  data: function(){
+  data: function() {
     return {
       locations: null,
+      searchTerm: "",
+
+      sortBy: '',
+      sortDesc: false,
+      sortDirection: 'asc',
+      filter: null,
+      filterOn: ["City"],
+      fields: [
+        {
+          key: 'City',
+          label: 'City',
+          filterByFormatted: true,
+          sortable: true,
+          sortDirection: 'desc',
+        },
+        { key: 'Name', label: 'Location Name' },
+        { key: 'Address', label: 'Address' },
+        { key: 'Zip', label: 'Zip' },
+        { key: 'Hours', label: 'Hours' },
+      ],
     }
   },
   methods: {
@@ -81,14 +166,20 @@ export default {
       this.getData();
     }
   },
+  computed: {
+    filteredLocations: function() {
+      // get the locations with a city name that match the search term
+      const searchTerm = this.searchTerm.toLowerCase();
+      const filteredLocs = this.locations.filter(loc => loc.City.toLowerCase().includes(searchTerm));
+      return filteredLocs;
+    }
+  },
   mounted() {
     this.getData();
   }
 }
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-
 
 </style>


### PR DESCRIPTION
See if this is fine.  Originally I was just doing a custom way of filtering the table (I committed it in the first commit), but switched to using the vue-bootstrap table element and its method of filtering.  The good thing about using the vue-bootstrap table is that we could easily filter/sort by other columns if we want.

Also, see if the verbiage is ok, ie "filter by city".  That wasn't mentioned, so I just went with something that seemed decent